### PR TITLE
Handle Duplicate Email Conflict in User Creation with Soft Deletes

### DIFF
--- a/src/modules/users/services/user.service.ts
+++ b/src/modules/users/services/user.service.ts
@@ -29,6 +29,18 @@ export class UserService {
           HttpStatus.CONFLICT,
         );
       }
+
+      const emailExists = await this.userRepository.findOne({
+        where: { email: user.email },
+        withDeleted: true,
+      });
+
+      if (emailExists) {
+        throw new HttpException(
+          res(false, 'Email already exists. Contact support.', null),
+          HttpStatus.CONFLICT,
+        );
+      }
       const userSaved = await this.userRepository.save(user);
       return res(true, 'User created', userSaved);
     } catch (error) {


### PR DESCRIPTION
This PR addresses the issue of creating a new user with an email that already exists in the database but has been soft deleted. The following changes were made:

- Added a check to include soft deleted records when verifying email existence during user creation.
- Throw an HttpException with a CONFLICT status and a message instructing the user to contact support if the email already exists.
- Updated the createUser method to handle this case appropriately.

These changes ensure that users are informed about the duplicate email issue and provide guidance to contact support for further assistance.
