### PR TITLE
Implement CRUD Operations for Categories with Swagger Documentation

### DIFF
--- a/src/modules/categories/categories.module.ts
+++ b/src/modules/categories/categories.module.ts
@@ -1,4 +1,13 @@
 import { Module } from '@nestjs/common';
+import { CategoryController } from './controllers/category.controller';
+import { CategoryService } from './services/category.service';
+import { Category } from './entities/category.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([Category])],
+  controllers: [CategoryController],
+  providers: [CategoryService],
+  exports: [],
+})
 export class CategoriesModule {}

--- a/src/modules/categories/controllers/category.controller.ts
+++ b/src/modules/categories/controllers/category.controller.ts
@@ -10,16 +10,39 @@ import {
 } from '@nestjs/common';
 import { CategoryService } from '../services/category.service';
 import { CreateCategoryDto, UpdateCategoryDto } from '../dtos';
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('Categories')
 @Controller('category')
 export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}
 
+  @ApiCreatedResponse({ description: 'Success' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
+  @ApiBadRequestResponse({ description: 'Bad Request' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Server Error' })
+  @ApiOperation({ summary: 'Create a category' })
   @Post('create')
   async createCategory(@Body() category: CreateCategoryDto) {
     return await this.categoryService.createCategory(category);
   }
 
+  @ApiOkResponse({ description: 'Success' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
+  @ApiBadRequestResponse({ description: 'Bad Request' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Server Error' })
+  @ApiOperation({ summary: 'Find all categories' })
   @Get('all')
   async findAllCategories(
     @Query('page') page: number = 1,
@@ -28,6 +51,11 @@ export class CategoryController {
     return await this.categoryService.findAllCategories(page, limit);
   }
 
+  @ApiOkResponse({ description: 'Success' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Server Error' })
+  @ApiOperation({ summary: 'Find categories by name' })
   @Get('find/:name')
   async findCategoryByName(
     @Param('name') name: string,
@@ -37,6 +65,12 @@ export class CategoryController {
     return await this.categoryService.findCategoryByName(name, page, limit);
   }
 
+  @ApiOkResponse({ description: 'Success' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
+  @ApiBadRequestResponse({ description: 'Bad Request' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Server Error' })
+  @ApiOperation({ summary: 'Update category' })
   @Put('update/:id')
   async updateCategory(
     @Param('id') id: number,
@@ -45,6 +79,11 @@ export class CategoryController {
     return await this.categoryService.updateCategory(id, updateCategory);
   }
 
+  @ApiOkResponse({ description: 'Success' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Server Error' })
+  @ApiOperation({ summary: 'Delete category' })
   @Delete('delete/:id')
   async deleteCategory(@Param('id') id: number) {
     return await this.categoryService.deleteCategory(id);

--- a/src/modules/categories/controllers/category.controller.ts
+++ b/src/modules/categories/controllers/category.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import { CategoryService } from '../services/category.service';
+import { CreateCategoryDto, UpdateCategoryDto } from '../dtos';
+
+@Controller('category')
+export class CategoryController {
+  constructor(private readonly categoryService: CategoryService) {}
+
+  @Post('create')
+  async createCategory(@Body() category: CreateCategoryDto) {
+    return await this.categoryService.createCategory(category);
+  }
+
+  @Get('all')
+  async findAllCategories(
+    @Query('page') page: number = 1,
+    @Query('limit') limit: number = 10,
+  ) {
+    return await this.categoryService.findAllCategories(page, limit);
+  }
+
+  @Get('find/:name')
+  async findCategoryByName(
+    @Param('name') name: string,
+    @Query('page') page: number = 1,
+    @Query('limit') limit: number = 10,
+  ) {
+    return await this.categoryService.findCategoryByName(name, page, limit);
+  }
+
+  @Put('update/:id')
+  async updateCategory(
+    @Param('id') id: number,
+    @Body() updateCategory: UpdateCategoryDto,
+  ) {
+    return await this.categoryService.updateCategory(id, updateCategory);
+  }
+
+  @Delete('delete/:id')
+  async deleteCategory(@Param('id') id: number) {
+    return await this.categoryService.deleteCategory(id);
+  }
+}

--- a/src/modules/categories/services/category.service.ts
+++ b/src/modules/categories/services/category.service.ts
@@ -1,0 +1,108 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Category } from '../entities/category.entity';
+import { ILike, Repository } from 'typeorm';
+import { CreateCategoryDto, UpdateCategoryDto } from '../dtos';
+import { ObjectResponse } from 'src/utils/interfaces/object-response.interface';
+import { res } from 'src/utils/res';
+
+@Injectable()
+export class CategoryService {
+  constructor(
+    @InjectRepository(Category)
+    private readonly categoryRepository: Repository<Category>,
+  ) {}
+
+  async createCategory(
+    category: CreateCategoryDto,
+  ): Promise<ObjectResponse<Category>> {
+    try {
+      const newCategory = this.categoryRepository.create(category);
+      const categorySaved = await this.categoryRepository.save(newCategory);
+      return res(true, 'Category created successfully', categorySaved);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async findAllCategories(
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<ObjectResponse<Category[]>> {
+    try {
+      const [categories, total] = await this.categoryRepository.findAndCount({
+        skip: (page - 1) * limit,
+        take: limit,
+      });
+      return res(true, 'Categories found', { categories, total });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async findCategoryByName(
+    name: string,
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<ObjectResponse<Category[]>> {
+    try {
+      const [category, total] = await this.categoryRepository.findAndCount({
+        where: { name: ILike(`%${name}%`) },
+        skip: (page - 1) * limit,
+        take: limit,
+      });
+
+      if (category.length === 0) {
+        return res(false, 'Category not found', category);
+      }
+
+      return res(true, 'Category found', { category, total });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async updateCategory(
+    id: number,
+    category: UpdateCategoryDto,
+  ): Promise<ObjectResponse<Category>> {
+    try {
+      const categoryExists = await this.categoryRepository.findOne({
+        where: { id },
+      });
+
+      if (!categoryExists) {
+        throw new NotFoundException(
+          res(false, `Category with ${id} not found`, null),
+        );
+      }
+
+      await this.categoryRepository.update(id, category);
+      const categoryUpdated = await this.categoryRepository.findOne({
+        where: { id },
+      });
+      return res(true, 'Category updated successfully', categoryUpdated);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async deleteCategory(id: number): Promise<ObjectResponse<Category>> {
+    try {
+      const categoryExists = await this.categoryRepository.findOne({
+        where: { id },
+      });
+
+      if (!categoryExists) {
+        throw new NotFoundException(
+          res(false, `Category with ${id} not found`, null),
+        );
+      }
+
+      await this.categoryRepository.softDelete(id);
+      return res(true, 'Category deleted successfully', categoryExists);
+    } catch (error) {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces the implementation of CRUD operations for the Category entity as per the user story requirements. The following changes have been made:

- Added `CategoryService` with methods for creating, finding, updating, and deleting categories.
- Added `CategoryController` with endpoints corresponding to CRUD operations.
- Implemented Swagger decorators for comprehensive API documentation.
- Implemented proper error handling and response formatting within the service.
- Enabled pagination for fetching all categories and searching categories by name.

All functionalities have been tested and are working as expected. The API documentation can now be generated and viewed through Swagger.
