### PR TITLE
feat(product-module): Implement CRUD operations and Swagger documentation for Products module

### DIFF
--- a/src/modules/products/controllers/product.controller.ts
+++ b/src/modules/products/controllers/product.controller.ts
@@ -10,21 +10,49 @@ import {
 } from '@nestjs/common';
 import { ProductService } from '../services/product.service';
 import { CreateProductDto, UpdateProductDto } from '../dtos';
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('Products')
 @Controller('product')
 export class ProductController {
   constructor(private readonly productService: ProductService) {}
 
+  @ApiCreatedResponse({ description: 'Success' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
+  @ApiBadRequestResponse({ description: 'Bad Request' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Server Error' })
+  @ApiOperation({ summary: 'Create a product' })
   @Post('create')
   async create(@Body() product: CreateProductDto) {
     return this.productService.create(product);
   }
 
+  @ApiOkResponse({ description: 'Success' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
+  @ApiBadRequestResponse({ description: 'Bad Request' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Server Error' })
+  @ApiOperation({ summary: 'Find all products' })
   @Get('all')
   async findAll(@Query('page') page: number, @Query('limit') limit: number) {
     return this.productService.findAll(page, limit);
   }
 
+  @ApiOkResponse({ description: 'Success' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Server Error' })
+  @ApiOperation({ summary: 'Find products by name' })
   @Get('find/:name')
   async findProductsByName(
     @Param('name') name: string,
@@ -34,11 +62,22 @@ export class ProductController {
     return this.productService.findProductsByName(name, page, limit);
   }
 
+  @ApiOkResponse({ description: 'Success' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
+  @ApiBadRequestResponse({ description: 'Bad Request' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Server Error' })
+  @ApiOperation({ summary: 'Update category' })
   @Put('update/:id')
   async update(@Param('id') id: number, @Body() product: UpdateProductDto) {
     return this.productService.updateProduct(id, product);
   }
 
+  @ApiOkResponse({ description: 'Success' })
+  @ApiNotFoundResponse({ description: 'Not Found' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Server Error' })
+  @ApiOperation({ summary: 'Delete category' })
   @Delete('delete/:id')
   async delete(@Param('id') id: number) {
     return this.productService.deleteProduct(id);

--- a/src/modules/products/controllers/product.controller.ts
+++ b/src/modules/products/controllers/product.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import { ProductService } from '../services/product.service';
+import { CreateProductDto, UpdateProductDto } from '../dtos';
+
+@Controller('product')
+export class ProductController {
+  constructor(private readonly productService: ProductService) {}
+
+  @Post('create')
+  async create(@Body() product: CreateProductDto) {
+    return this.productService.create(product);
+  }
+
+  @Get('all')
+  async findAll(@Query('page') page: number, @Query('limit') limit: number) {
+    return this.productService.findAll(page, limit);
+  }
+
+  @Get('find/:name')
+  async findProductsByName(
+    @Param('name') name: string,
+    @Query('page') page: number = 1,
+    @Query('limit') limit: number = 10,
+  ) {
+    return this.productService.findProductsByName(name, page, limit);
+  }
+
+  @Put('update/:id')
+  async update(@Param('id') id: number, @Body() product: UpdateProductDto) {
+    return this.productService.updateProduct(id, product);
+  }
+
+  @Delete('delete/:id')
+  async delete(@Param('id') id: number) {
+    return this.productService.deleteProduct(id);
+  }
+}

--- a/src/modules/products/products.module.ts
+++ b/src/modules/products/products.module.ts
@@ -1,4 +1,14 @@
 import { Module } from '@nestjs/common';
+import { ProductController } from './controllers/product.controller';
+import { ProductService } from './services/product.service';
+import { Product } from './entities/product.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Category } from '../categories/entities/category.entity';
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([Product, Category])],
+  controllers: [ProductController],
+  providers: [ProductService],
+  exports: [],
+})
 export class ProductsModule {}

--- a/src/modules/products/services/product.service.ts
+++ b/src/modules/products/services/product.service.ts
@@ -1,0 +1,150 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Product } from '../entities/product.entity';
+import { ILike, Repository } from 'typeorm';
+import { CreateProductDto, UpdateProductDto } from '../dtos';
+import { ObjectResponse } from 'src/utils/interfaces/object-response.interface';
+import { res } from 'src/utils/res';
+import { Category } from 'src/modules/categories/entities/category.entity';
+
+@Injectable()
+export class ProductService {
+  constructor(
+    @InjectRepository(Product)
+    private readonly productRepository: Repository<Product>,
+    @InjectRepository(Category)
+    private readonly categoryRepository: Repository<Category>,
+  ) {}
+
+  async create(product: CreateProductDto): Promise<ObjectResponse<Product>> {
+    try {
+      const category = await this.categoryRepository.findOne({
+        where: { id: product.category_id },
+      });
+
+      if (!category) {
+        throw new NotFoundException(
+          res(false, `Category with ID ${product.category_id} not found`, null),
+        );
+      }
+
+      const newProduct = this.productRepository.create(product);
+      newProduct.category = category;
+      const productSaved = await this.productRepository.save(newProduct);
+
+      const productWithRelations = await this.productRepository.findOne({
+        where: { id: productSaved.id },
+        relations: ['category'],
+      });
+
+      return res(true, 'Product created successfully', productWithRelations);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async findAll(
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<ObjectResponse<Product[]>> {
+    try {
+      const [products, total] = await this.productRepository.findAndCount({
+        skip: (page - 1) * limit,
+        take: limit,
+        relations: ['category'],
+      });
+      return res(true, 'Products found', { products, total });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async findProductsByName(
+    name: string,
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<ObjectResponse<Product[]>> {
+    try {
+      const [products, total] = await this.productRepository.findAndCount({
+        where: { name: ILike(`%${name}%`) },
+        skip: (page - 1) * limit,
+        take: limit,
+        relations: ['category'],
+      });
+
+      if (products.length === 0) {
+        throw new NotFoundException(
+          res(false, `Product with name ${name} not found`, null),
+        );
+      }
+
+      return res(true, 'Products found', { products, total });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async updateProduct(
+    id: number,
+    product: UpdateProductDto,
+  ): Promise<ObjectResponse<Product>> {
+    try {
+      const productExists = await this.productRepository.findOne({
+        where: { id },
+        relations: ['category'],
+      });
+
+      if (!productExists) {
+        throw new NotFoundException(
+          res(false, `Product with ID ${id} not found`, null),
+        );
+      }
+
+      if (product.category_id) {
+        const category = await this.categoryRepository.findOne({
+          where: { id: product.category_id },
+        });
+        if (!category) {
+          throw new NotFoundException(
+            res(
+              false,
+              `Category with ID ${product.category_id} not found`,
+              null,
+            ),
+          );
+        }
+        productExists.category = category;
+      }
+
+      await this.productRepository.save({ ...productExists, ...product });
+
+      const productUpdated = await this.productRepository.findOne({
+        where: { id },
+        relations: ['category'],
+      });
+      return res(true, 'Product updated successfully', productUpdated);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async deleteProduct(id: number): Promise<ObjectResponse<Product>> {
+    try {
+      const productExists = await this.productRepository.findOne({
+        where: { id },
+        relations: ['category'],
+      });
+
+      if (!productExists) {
+        throw new NotFoundException(
+          res(false, `Product with ID ${id} not found`, null),
+        );
+      }
+
+      await this.productRepository.softDelete(id);
+      return res(true, 'Product deleted successfully', productExists);
+    } catch (error) {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the CRUD operations functionality for managing products in the system. It includes endpoints for creating, reading, updating, and deleting products. Additionally, Swagger decorators have been added to ensure comprehensive API documentation. The implementation also ensures proper handling of relationships with other entities, such as categories, enhancing the overall functionality and usability of the product module.

- Added ProductService with methods for:
  - create: Create a new product and associate with category
  - findAll: Retrieve all products with pagination and category info
  - findProductsByName: Find products by name with pagination and category info
  - updateProduct: Update product details and category
  - deleteProduct: Soft delete a product by ID

- Added ProductController with endpoints:
  - POST /product/create
  - GET /product/all
  - GET /product/find/:name
  - PUT /product/update/:id
  - DELETE /product/delete/:id

- Added Swagger decorators to ProductController methods:
  - POST /product/create
  - GET /product/all
  - GET /product/find/:name
  - PUT /product/update/:id
  - DELETE /product/delete/:id