### PR TITLE
feat: Add CRUD operations for Order module

### DIFF
--- a/src/modules/orders/controllers/order.controller.ts
+++ b/src/modules/orders/controllers/order.controller.ts
@@ -1,0 +1,43 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import { OrderService } from '../services/order.service';
+import { CreateOrderDto } from '../dtos';
+
+@Controller('order')
+export class OrderController {
+  constructor(private readonly orderService: OrderService) {}
+
+  @Post('create')
+  async createOrder(@Body() createOrderDto: CreateOrderDto) {
+    return this.orderService.createOrder(createOrderDto);
+  }
+
+  @Get('all')
+  async getAllOrders(
+    @Query('page') page: number = 1,
+    @Query('limit') limit: number = 10,
+  ) {
+    return this.orderService.findAllOrders(page, limit);
+  }
+
+  @Put('update/:id')
+  async updateOrder(
+    @Param('id') id: number,
+    @Body() updateOrderDto: CreateOrderDto,
+  ) {
+    return this.orderService.updateOrder(id, updateOrderDto);
+  }
+
+  @Delete('delete/:id')
+  async deleteOrder(@Param('id') id: number) {
+    return this.orderService.deleteOrder(id);
+  }
+}

--- a/src/modules/orders/orders.module.ts
+++ b/src/modules/orders/orders.module.ts
@@ -1,4 +1,15 @@
 import { Module } from '@nestjs/common';
+import { OrderService } from './services/order.service';
+import { OrderController } from './controllers/order.controller';
+import { Type } from 'class-transformer';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Order } from './entities/order.entity';
+import { Product } from '../products/entities/product.entity';
+import { OrderDetail } from './entities/order-detail.entity';
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([Order, OrderDetail, Product])],
+  controllers: [OrderController],
+  providers: [OrderService],
+})
 export class OrdersModule {}

--- a/src/modules/orders/orders.module.ts
+++ b/src/modules/orders/orders.module.ts
@@ -6,9 +6,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Order } from './entities/order.entity';
 import { Product } from '../products/entities/product.entity';
 import { OrderDetail } from './entities/order-detail.entity';
+import { User } from '../users/entities/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Order, OrderDetail, Product])],
+  imports: [TypeOrmModule.forFeature([Order, OrderDetail, Product, User])],
   controllers: [OrderController],
   providers: [OrderService],
 })

--- a/src/modules/orders/services/order.service.ts
+++ b/src/modules/orders/services/order.service.ts
@@ -1,0 +1,256 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Order } from '../entities/order.entity';
+import { Repository } from 'typeorm';
+import { OrderDetail } from '../entities/order-detail.entity';
+import { Product } from 'src/modules/products/entities/product.entity';
+import { User } from 'src/modules/users/entities/user.entity';
+import { CreateOrderDto, UpdateOrderDto } from '../dtos';
+import { ObjectResponse } from 'src/utils/interfaces/object-response.interface';
+import { res } from 'src/utils/res';
+
+@Injectable()
+export class OrderService {
+  constructor(
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
+    @InjectRepository(OrderDetail)
+    private readonly orderDetailRepository: Repository<OrderDetail>,
+    @InjectRepository(Product)
+    private readonly productRepository: Repository<Product>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async createOrder(
+    createOrderDto: CreateOrderDto,
+  ): Promise<ObjectResponse<Order>> {
+    try {
+      const { user_id, order_details } = createOrderDto;
+      const user = await this.userRepository.findOne({
+        where: { id: user_id },
+      });
+
+      if (!user) {
+        throw new NotFoundException(
+          res(false, `User with id ${user_id} not found`, null),
+        );
+      }
+
+      const order = new Order();
+      order.order_date = new Date();
+      order.user = user;
+
+      let totalAmount = 0;
+      const orderDetails: OrderDetail[] = [];
+      for (const detail of order_details) {
+        const product = await this.productRepository.findOne({
+          where: { id: detail.product_id },
+        });
+
+        if (!product) {
+          throw new NotFoundException(
+            res(false, `Product with id ${detail.product_id} not found`, null),
+          );
+        }
+
+        if (detail.quantity > product.stock) {
+          throw new BadRequestException(
+            res(false, `Insufficient stock for product ${product.name}`, null),
+          );
+        }
+
+        const orderDetail = new OrderDetail();
+        orderDetail.product = product;
+        orderDetail.quantity = detail.quantity;
+        orderDetail.order = order;
+
+        orderDetails.push(orderDetail);
+
+        totalAmount += product.price * detail.quantity;
+      }
+
+      const createdOrder = await this.orderRepository.manager.transaction(
+        async (transactionalEntityManager) => {
+          order.total_amount = totalAmount;
+          order.orderDetails = orderDetails;
+
+          await Promise.all(
+            orderDetails.map(async (detail) => {
+              const product = detail.product;
+              product.stock -= detail.quantity;
+              await transactionalEntityManager.save(product);
+            }),
+          );
+          const savedOrder = await transactionalEntityManager.save(order);
+          await transactionalEntityManager.save(orderDetails);
+
+          return savedOrder;
+        },
+      );
+
+      const responseOrder = {
+        ...createdOrder,
+        orderDetails: createdOrder.orderDetails.map((detail) => {
+          const { order, ...detailWithoutOrder } = detail;
+          return detailWithoutOrder;
+        }),
+      };
+
+      return res(true, 'Order created successfully', responseOrder);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async findAllOrders(
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<ObjectResponse<Order[]>> {
+    try {
+      const [orders, total] = await this.orderRepository.findAndCount({
+        skip: (page - 1) * limit,
+        take: limit,
+        relations: ['user', 'orderDetails'],
+      });
+
+      return res(true, 'Orders retrieved successfully', { orders, total });
+    } catch (error) {}
+  }
+
+  async updateOrder(
+    id: number,
+    updateOrderDto: UpdateOrderDto,
+  ): Promise<ObjectResponse<Order>> {
+    try {
+      const orderToUpdate = await this.orderRepository.findOne({
+        where: { id },
+        relations: ['user', 'orderDetails'],
+      });
+
+      if (!orderToUpdate) {
+        throw new NotFoundException(
+          res(false, `Order with id ${id} not found`, null),
+        );
+      }
+
+      if (updateOrderDto.user_id) {
+        const userExists = await this.userRepository.findOne({
+          where: { id: updateOrderDto.user_id },
+        });
+        if (!userExists) {
+          throw new NotFoundException(
+            res(
+              false,
+              `User with id ${updateOrderDto.user_id} not found`,
+              null,
+            ),
+          );
+        }
+        orderToUpdate.user = userExists;
+      }
+
+      if (updateOrderDto.order_details) {
+        const orderDetailsToUpdate: OrderDetail[] = [];
+
+        for (const detail of updateOrderDto.order_details) {
+          const product = await this.productRepository.findOne({
+            where: { id: detail.product_id },
+          });
+
+          if (!product) {
+            throw new NotFoundException(
+              res(
+                false,
+                `Product with id ${detail.product_id} not found`,
+                null,
+              ),
+            );
+          }
+
+          if (detail.quantity > product.stock) {
+            throw new BadRequestException(
+              res(
+                false,
+                `Insufficient stock for product ${product.name}`,
+                null,
+              ),
+            );
+          }
+
+          let orderDetail = orderToUpdate.orderDetails.find(
+            (od) => od.product && od.product.id === product.id,
+          );
+
+          if (!orderDetail) {
+            orderDetail = new OrderDetail();
+            orderDetail.product = product;
+            orderDetail.order = orderToUpdate;
+          }
+          orderDetail.quantity = detail.quantity;
+
+          orderDetailsToUpdate.push(orderDetail);
+        }
+
+        // Remove old order details
+        const oldOrderDetails = orderToUpdate.orderDetails.filter(
+          (od) => !orderDetailsToUpdate.includes(od),
+        );
+        await this.orderDetailRepository.remove(oldOrderDetails);
+
+        // Update with new order details
+        orderToUpdate.orderDetails = orderDetailsToUpdate;
+      }
+
+      let totalAmount = 0;
+      for (const detail of orderToUpdate.orderDetails) {
+        if (detail.product) {
+          totalAmount += detail.product.price * detail.quantity;
+        }
+      }
+      orderToUpdate.total_amount = totalAmount;
+
+      const updatedOrder = await this.orderRepository.save(orderToUpdate);
+
+      const simpleOrder = {
+        ...updatedOrder,
+        orderDetails: updatedOrder.orderDetails.map((detail) => ({
+          ...detail,
+          order: undefined,
+        })),
+      };
+
+      return res(true, 'Order updated successfully', simpleOrder);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async deleteOrder(id: number): Promise<ObjectResponse<Order>> {
+    try {
+      const orderToDelete = await this.orderRepository.findOne({
+        where: { id },
+        relations: ['orderDetails'],
+      });
+
+      if (!orderToDelete) {
+        throw new NotFoundException(
+          res(false, `Order with id ${id} not found`, null),
+        );
+      }
+
+      for (const detail of orderToDelete.orderDetails) {
+        await this.orderDetailRepository.softDelete(detail.id);
+      }
+
+      await this.orderRepository.softDelete(id);
+      return res(true, 'Order deleted successfully', orderToDelete);
+    } catch (error) {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
This pull request implements the CRUD operations for the Order module, including the following features:

- **Create Order**: A new order can be created with associated user and order details. The total amount is calculated on the backend based on product prices and quantities.
- **Retrieve Orders**: Orders can be retrieved in a paginated manner, including details about the user and order details.
- **Update Order**: Existing orders can be updated, including changing the user and updating order details. The total amount is recalculated based on the updated order details.
- **Delete Order**: Orders and their associated order details can be soft deleted.

Error handling has been enhanced to ensure meaningful messages are returned for not found and bad request scenarios.

This implementation ensures the Order module is fully functional and integrates well with the existing user and product modules.
