### PR TITLE
Fix Product Stock Update on Order Deletion

### DIFF
--- a/src/modules/products/controllers/product.controller.ts
+++ b/src/modules/products/controllers/product.controller.ts
@@ -67,7 +67,7 @@ export class ProductController {
   @ApiBadRequestResponse({ description: 'Bad Request' })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   @ApiInternalServerErrorResponse({ description: 'Server Error' })
-  @ApiOperation({ summary: 'Update category' })
+  @ApiOperation({ summary: 'Update product' })
   @Put('update/:id')
   async update(@Param('id') id: number, @Body() product: UpdateProductDto) {
     return this.productService.updateProduct(id, product);
@@ -77,7 +77,7 @@ export class ProductController {
   @ApiNotFoundResponse({ description: 'Not Found' })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   @ApiInternalServerErrorResponse({ description: 'Server Error' })
-  @ApiOperation({ summary: 'Delete category' })
+  @ApiOperation({ summary: 'Delete product' })
   @Delete('delete/:id')
   async delete(@Param('id') id: number) {
     return this.productService.deleteProduct(id);


### PR DESCRIPTION
This pull request addresses an issue where product stock was not being incremented correctly upon order deletion. The key changes include:

- Ensuring the `product` relationship is loaded when fetching order details.
- Incrementing the product stock based on the quantities in the order details before deleting them.
- Soft deleting the order and its details while preserving the stock adjustments.

These changes ensure the product stock is accurately updated when an order is deleted, maintaining the integrity of the inventory system.
