### PR TITLE
Fix Product Stock Update on Order Deletion

### DIFF
--- a/src/modules/orders/controllers/order.controller.ts
+++ b/src/modules/orders/controllers/order.controller.ts
@@ -69,7 +69,7 @@ export class OrderController {
   @ApiNotFoundResponse({ description: 'Not Found' })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   @ApiInternalServerErrorResponse({ description: 'Server Error' })
-  @ApiOperation({ summary: 'Delete category' })
+  @ApiOperation({ summary: 'Delete order' })
   @Delete('delete/:id')
   async deleteOrder(@Param('id') id: number) {
     return this.orderService.deleteOrder(id);

--- a/src/modules/orders/services/order.service.ts
+++ b/src/modules/orders/services/order.service.ts
@@ -234,7 +234,7 @@ export class OrderService {
     try {
       const orderToDelete = await this.orderRepository.findOne({
         where: { id },
-        relations: ['orderDetails'],
+        relations: ['orderDetails', 'orderDetails.product'],
       });
 
       if (!orderToDelete) {
@@ -244,6 +244,11 @@ export class OrderService {
       }
 
       for (const detail of orderToDelete.orderDetails) {
+        const product = detail.product;
+        if (product) {
+          product.stock += detail.quantity;
+          await this.productRepository.save(product);
+        }
         await this.orderDetailRepository.softDelete(detail.id);
       }
 


### PR DESCRIPTION
This pull request addresses an issue where product stock was not being incremented correctly upon order deletion. The key changes include:

- Ensuring the `product` relationship is loaded when fetching order details.
- Incrementing the product stock based on the quantities in the order details before deleting them.
- Soft deleting the order and its details while preserving the stock adjustments.

These changes ensure the product stock is accurately updated when an order is deleted, maintaining the integrity of the inventory system.
